### PR TITLE
chore: Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Composer
+/vendor/
+composer.lock
+
+# PHPUnit
+/phpunit.xml
+/phpunit.result.cache
+/build/
+/coverage/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Log files
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Sass cache
+.sass-cache/
+
+# Node modules (if any frontend part is ever added)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
Added a standard .gitignore file for PHP/Composer projects to exclude vendor directory, lock file, IDE specific files, logs, and other common temporary files from version control.