### PR TITLE
feat: Add PHP-CS-Fixer for code style consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Composer
 /vendor/
 composer.lock
+.php-cs-fixer.cache
 
 # PHPUnit
 /phpunit.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,126 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+        '@PSR12' => true,
+        'strict_param' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'binary_operator_spaces' => [
+            'default' => 'single_space',
+            'operators' => ['=>' => null]
+        ],
+        'blank_line_after_namespace' => true,
+        'blank_line_after_opening_tag' => true,
+        'blank_line_before_statement' => [
+            'statements' => ['return', 'throw', 'try', 'if', 'foreach', 'while', 'do', 'switch']
+        ],
+        'braces' => true,
+        'cast_spaces' => true,
+        'class_attributes_separation' => [
+            'elements' => ['method' => 'one', 'trait_import' => 'none']
+        ],
+        'class_definition' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => true,
+        'elseif' => true,
+        'encoding' => true,
+        'full_opening_tag' => true,
+        'fully_qualified_strict_types' => true, // Transforms imported FQCN parameters and return types in function arguments to short version.
+        'function_declaration' => true,
+        'function_typehint_space' => true,
+        'heredoc_to_nowdoc' => true,
+        'include' => true,
+        'increment_style' => ['style' => 'post'],
+        'indentation_type' => true,
+        'linebreak_after_opening_tag' => true,
+        'line_ending' => true,
+        'lowercase_cast' => true,
+        'constant_case' => ['case' => 'lower'], // Example, can be 'upper'
+        'lowercase_keywords' => true,
+        'lowercase_static_reference' => true, // static::class ...
+        'magic_method_casing' => true, // magic methods must be defined with __toString
+        'magic_constant_casing' => true,
+        'method_argument_space' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_extra_blank_lines' => [
+            'tokens' => [
+                'extra',
+                'throw',
+                'use',
+                'use_trait',
+            ]
+        ],
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_closing_tag' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_leading_import_slash' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_mixed_echo_print' => ['use' => 'echo'],
+        'no_multiline_whitespace_around_double_arrow' => true,
+        'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_after_function_name' => true,
+        'no_spaces_around_offset' => true,
+        'no_spaces_inside_parenthesis' => true,
+        'no_trailing_comma_in_list_call' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unreachable_default_argument_value' => true,
+        'no_useless_return' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'normalize_index_brace' => true,
+        'not_operator_with_successor_space' => true,
+        'object_operator_without_whitespace' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'phpdoc_indent' => true,
+        'phpdoc_inline_tag_normalizer' => true,
+        'phpdoc_no_access' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_summary' => true,
+        'phpdoc_to_comment' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_var_without_name' => true,
+        'psr_autoloading' => true,
+        'self_accessor' => true,
+        'short_scalar_cast' => true,
+        'simplified_null_return' => false, // disabled as it can change behaviour of code returning mixed types
+        'single_blank_line_at_eof' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_class_element_per_statement' => true,
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+        'single_line_comment_style' => [
+            'comment_types' => ['hash']
+        ],
+        'single_quote' => true,
+        'space_after_semicolon' => true,
+        'standardize_not_equals' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arrays']],
+        'trim_array_spaces' => true,
+        'unary_operator_spaces' => true,
+        'visibility_required' => ['elements' => ['property', 'method', 'const']],
+        'whitespace_after_comma_in_array' => true,
+    ])
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
+    ->setUsingCache(true);

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Iceshell21
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": "^8.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5",
+        "friendsofphp/php-cs-fixer": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -26,7 +27,9 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "lint": "php-cs-fixer fix --diff --dry-run --config=.php-cs-fixer.dist.php",
+        "format": "php-cs-fixer fix --config=.php-cs-fixer.dist.php"
     },
     "minimum-stability": "stable"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         stopOnFailure="false"
+         stopOnError="false">
+
+    <testsuites>
+        <testsuite name="Iceshell21 JWT Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="php://stdout" showUncoveredFiles="false" showOnlySummary="true"/>
+        </report>
+    </coverage>
+
+    <logging>
+        <junit outputFile="build/logs/junit.xml"/>
+    </logging>
+
+    <php>
+        <!-- <ini name="error_reporting" value="-1" /> -->
+        <!-- <env name="APP_ENV" value="testing"/> -->
+        <!-- <env name="CACHE_DRIVER" value="array"/> -->
+        <!-- <env name="SESSION_DRIVER" value="array"/> -->
+        <!-- <env name="QUEUE_DRIVER" value="sync"/> -->
+    </php>
+</phpunit>

--- a/src/Exception/BeforeValidTokenException.php
+++ b/src/Exception/BeforeValidTokenException.php
@@ -7,6 +7,4 @@ namespace Iceshell21\Jwt\Exception;
 /**
  * Exception thrown when a token is used before its 'nbf' (not before) time.
  */
-class BeforeValidTokenException extends InvalidTokenException
-{
-}
+class BeforeValidTokenException extends InvalidTokenException {}

--- a/src/Exception/ExpiredTokenException.php
+++ b/src/Exception/ExpiredTokenException.php
@@ -8,6 +8,4 @@ namespace Iceshell21\Jwt\Exception;
  * Exception thrown when a token has expired.
  * This corresponds to the 'exp' (expiration time) claim.
  */
-class ExpiredTokenException extends InvalidTokenException
-{
-}
+class ExpiredTokenException extends InvalidTokenException {}

--- a/src/Exception/InvalidTokenException.php
+++ b/src/Exception/InvalidTokenException.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Iceshell21\Jwt\Exception;
 
+use RuntimeException; // Added for fully_qualified_strict_types
+
 /**
  * Exception thrown when a token is invalid for reasons other than signature, expiration, or not-before time.
  * For example, malformed token, incorrect number of segments, invalid JSON, missing claims.
  */
-class InvalidTokenException extends \RuntimeException implements JwtExceptionInterface
-{
-}
+class InvalidTokenException extends RuntimeException implements JwtExceptionInterface {}

--- a/src/Exception/SignatureInvalidException.php
+++ b/src/Exception/SignatureInvalidException.php
@@ -7,6 +7,4 @@ namespace Iceshell21\Jwt\Exception;
 /**
  * Exception thrown when a token's signature is invalid.
  */
-class SignatureInvalidException extends InvalidTokenException
-{
-}
+class SignatureInvalidException extends InvalidTokenException {}

--- a/tests/JwtManagerTest.php
+++ b/tests/JwtManagerTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Iceshell21\Jwt\Tests;
 
-use Iceshell21\Jwt\JwtManager;
+use DateTimeImmutable;
+use Iceshell21\Jwt\Exception\BeforeValidTokenException;
 use Iceshell21\Jwt\Exception\ExpiredTokenException;
 use Iceshell21\Jwt\Exception\InvalidTokenException;
+use Iceshell21\Jwt\Exception\JwtExceptionInterface; // Keep if used, remove if not
 use Iceshell21\Jwt\Exception\SignatureInvalidException;
-use Iceshell21\Jwt\Exception\BeforeValidTokenException;
-use Iceshell21\Jwt\Exception\JwtExceptionInterface;
+use Iceshell21\Jwt\JwtManager;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use DateTimeImmutable;
+use RuntimeException;
 
 class JwtManagerTest extends TestCase
 {
@@ -304,14 +306,14 @@ class JwtManagerTest extends TestCase
 
     public function testConstructorWithEmptySecretThrowsException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Secret key cannot be empty.');
         new JwtManager('');
     }
 
     public function testConstructorWithUnsupportedAlgorithmThrowsException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unsupported algorithm: FOO123.'); // Message includes the list
         new JwtManager('secret', 'FOO123');
     }
@@ -472,7 +474,7 @@ class JwtManagerTest extends TestCase
         if ($decoded === false) {
             // This is a simplified check; JwtManager's internal method might be more robust
             // or throw its own specific exception. For this test helper, RuntimeException is fine.
-            throw new \RuntimeException("Test helper base64UrlDecode failed for data: $data");
+            throw new RuntimeException("Test helper base64UrlDecode failed for data: {$data}");
         }
         return $decoded;
     }
@@ -483,6 +485,6 @@ class JwtManagerTest extends TestCase
             return hash_hmac('sha256', $data, $key, true);
         }
         // Extend for other algorithms if JwtManager supports them and tests need them
-        throw new \InvalidArgumentException("Test helper signUsingJwtManagerInternals does not support algorithm: {$algorithm}");
+        throw new InvalidArgumentException("Test helper signUsingJwtManagerInternals does not support algorithm: {$algorithm}");
     }
 }


### PR DESCRIPTION
- Added `friendsofphp/php-cs-fixer` to dev dependencies.
- Created `.php-cs-fixer.dist.php` configuration file with PSR-12 rules and customisations.
- Added `lint` and `format` scripts to `composer.json`.
- Updated `.gitignore` to exclude PHP-CS-Fixer cache files.
- Applied initial formatting changes to sort use statements and update exception class references.

User should run `composer format` to apply full styling.